### PR TITLE
[FIX] web: o2m pager when empty

### DIFF
--- a/addons/web/static/src/js/view_form.js
+++ b/addons/web/static/src/js/view_form.js
@@ -4607,10 +4607,10 @@ instance.web.form.One2ManyListView = instance.web.ListView.extend({
         return this._super(record);
     },
     reload_content: function () {
-        this.page = Math.min(
+        this.page = Math.max(0, Math.min(
             this.page,
             Math.ceil(this.dataset.size() / this.limit()) - 1
-        );
+        ));
         return this._super.apply(this, arguments);
     },
 });


### PR DESCRIPTION
Commit 704b3cec9f37f76c5e1adad88d2a33b86ea11ed7 introduced a bug which led to be on page -1 on
empty o2m. So when adding a record to such a o2m, the reload content
function chose to stay on page -1 therefore not displaying the new
added record.